### PR TITLE
Use Docker secrets for Postgres password

### DIFF
--- a/.secrets/POSTGRES_PASSWORD.example
+++ b/.secrets/POSTGRES_PASSWORD.example
@@ -1,0 +1,5 @@
+# Example secret file for Docker secrets
+# Populate a real password and create the Docker secret with:
+#   echo "yourpassword" | docker secret create postgres_password -
+
+cookbook_dev_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,14 @@ services:
     environment:
       POSTGRES_DB: cookbook
       POSTGRES_USER: cookbook
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-cookbook_dev_password}
+      # POSTGRES_PASSWORD is provided via Docker secret `postgres_password`
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
+    secrets:
+      - postgres_password
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U cookbook"]
       interval: 5s
@@ -20,7 +23,7 @@ services:
     build: .
     container_name: cookbook-web
     environment:
-      DATABASE_URL: postgresql://cookbook:${POSTGRES_PASSWORD:-cookbook_dev_password}@db:5432/cookbook
+      DATABASE_URL: postgresql://cookbook:${POSTGRES_PASSWORD}@db:5432/cookbook
       SECRET_KEY: ${SECRET_KEY:-}
       FLASK_APP: wsgi.py
     ports:
@@ -28,6 +31,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    secrets:
+      - postgres_password
     volumes:
       - ./app:/app/app
       - ./migrations:/app/migrations
@@ -35,3 +40,7 @@ services:
 
 volumes:
   postgres_data:
+
+secrets:
+  postgres_password:
+    external: true


### PR DESCRIPTION
This PR switches docker-compose to expect an external Docker secret named 'postgres_password' and adds an example secret file (.secrets/POSTGRES_PASSWORD.example). Create the secret with:\n\necho "yourpassword" | docker secret create postgres_password -\n\nThe secret is marked external to avoid checking secrets into the repo.